### PR TITLE
chore(ci): use GH Packages + checkout v4 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
 
 permissions:
   contents: write
@@ -14,15 +13,34 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node (GitHub Packages)
+        uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-      - run: npm ci
-      - uses: changesets/action@v1
+          cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@codeiqlabs'
+
+      - name: Install
+        run: npm ci
+
+      # Will either:
+      #  - open/refresh a "Version Packages" PR when there are pending changesets, or
+      #  - publish after that PR is merged (creating a Git tag + GitHub Release).
+      - name: Create release PR or publish
+        uses: changesets/action@v1
         with:
           publish: npm publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Optional debugging
+      - name: Who am I?
+        if: always()
+        run: |
+          npm config get registry
+          npm whoami || true

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Shared ESLint v9 flat config for CodeIQLabs projects",
   "main": "index.js",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
-    "access": "public"
+    "registry": "https://npm.pkg.github.com"
   },
   "exports": {
     ".": "./index.js",


### PR DESCRIPTION
## Summary
- publish releases to GitHub Packages
- use checkout v4 in release workflow
- rely on GITHUB_TOKEN for publish authentication

## Testing
- `npm test`
