### PR TITLE
chore: publish package publicly with tagging strategy

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,7 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
+  "tag": "v{{version}}",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ coverage
 .turbo
 .idea
 .terraform
+src/prettier.config.ts

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   ],
   "sideEffects": false,
   "publishConfig": {
+    "access": "public",
+    "tag": "latest",
     "registry": "https://npm.pkg.github.com"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- configure Changesets to tag releases with `v` prefix
- publish package to GitHub Packages with public access and `latest` dist-tag
- ignore internal Prettier config file from formatting

## Testing
- `npm test`
- `npm run format:check` *(fails: Unknown file extension ".ts" for src/prettier.config.ts)*
